### PR TITLE
Update README.md to point to USGS-CMG, not rsignell-usgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About yaml2ncml
 ===============
 
-Home: https://github.com/rsignell-usgs/yaml2ncml
+Home: https://github.com/USGS-CMG/yaml2ncml
 
 Package license: MIT
 


### PR DESCRIPTION
Update README.md to reference  USGS-CMG (master), not rsignell-usgs (a fork)
