### PR TITLE
Bump from 0.4 to 0.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.0" %}
+{% set version = "0.6.0" %}
 
 package:
     name: yaml2ncml


### PR DESCRIPTION
- adds support for variables that depend on Nbed
- python 3 compliant